### PR TITLE
Make whitelist configurable

### DIFF
--- a/src/delegation_backend/app_config.go
+++ b/src/delegation_backend/app_config.go
@@ -59,9 +59,21 @@ func LoadEnv(log logging.EventLogger) AppConfig {
 			log.Fatal("missing AWS_ACCOUNT_ID environment variable")
 		}
 
+		delegationWhitelistList := os.Getenv("DELEGATION_WHITELIST_LIST")
+		if delegationWhitelistList == "" {
+			log.Fatal("missing DELEGATION_WHITELIST_LIST environment variable")
+		}
+
+		delegationWhitelistColumn := os.Getenv("DELEGATION_WHITELIST_COLUMN")
+		if delegationWhitelistColumn == "" {
+			log.Fatal("missing DELEGATION_WHITELIST_COLUMN environment variable")
+		}
+
 		config = AppConfig{
-			NetworkName: networkName,
-			GsheetId:    gsheetId,
+			NetworkName:               networkName,
+			GsheetId:                  gsheetId,
+			DelegationWhitelistList:   delegationWhitelistList,
+			DelegationWhitelistColumn: delegationWhitelistColumn,
 			Aws: AwsConfig{
 				Region:    awsRegion,
 				AccountId: awsAccountId,
@@ -83,9 +95,11 @@ type AwsConfig struct {
 }
 
 type AppConfig struct {
-	Aws         AwsConfig `json:"aws"`
-	NetworkName string    `json:"network_name"`
-	GsheetId    string    `json:"gsheet_id"`
+	Aws                       AwsConfig `json:"aws"`
+	NetworkName               string    `json:"network_name"`
+	GsheetId                  string    `json:"gsheet_id"`
+	DelegationWhitelistList   string    `json:"delegation_whitelist_list"`
+	DelegationWhitelistColumn string    `json:"delegation_whitelist_column"`
 }
 
 type AwsCredentials struct {

--- a/src/delegation_backend/constants.go
+++ b/src/delegation_backend/constants.go
@@ -10,8 +10,6 @@ const REQUESTS_PER_PK_HOURLY = 120
 const DELEGATION_BACKEND_LISTEN_TO = ":8080"
 const TIME_DIFF_DELTA time.Duration = -5 * 60 * 1000000000 // -5m
 const WHITELIST_REFRESH_INTERVAL = 10 * 60 * 1000000000    // 10m
-const DELEGATION_WHITELIST_LIST = "Form Responses 1"
-const DELEGATION_WHITELIST_COLUMN = "E"
 
 var PK_PREFIX = [...]byte{1, 1}
 var SIG_PREFIX = [...]byte{1}

--- a/src/delegation_backend/sheets.go
+++ b/src/delegation_backend/sheets.go
@@ -28,8 +28,8 @@ func processRows(rows [][](interface{})) Whitelist {
 // and extract public keys out of the column containing
 // public keys of program participants.
 func RetrieveWhitelist(service *sheets.Service, log *logging.ZapEventLogger, appCfg AppConfig) Whitelist {
-	col := DELEGATION_WHITELIST_COLUMN
-	readRange := DELEGATION_WHITELIST_LIST + "!" + col + ":" + col
+	col := appCfg.DelegationWhitelistColumn
+	readRange := appCfg.DelegationWhitelistList + "!" + col + ":" + col
 	spId := appCfg.GsheetId
 	resp, err := service.Spreadsheets.Values.Get(spId, readRange).Do()
 	if err != nil {


### PR DESCRIPTION
This PR turns whitelist settings from constant to configurable via environment variables (`DELEGATION_WHITELIST_LIST` and `DELEGATION_WHITELIST_COLUMN`) or config file `{ ..., "delegation_whitelist_list": ..., "delegation_whitelist_column": ... }`.