### PR TITLE
Fix submit tests

### DIFF
--- a/src/delegation_backend/submit_test.go
+++ b/src/delegation_backend/submit_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -15,6 +16,13 @@ import (
 
 const TSPG_EXPECTED_1 = `{"block":"zLgvHQzxSh8MWlTjXK+cMA==","created_at":"2021-07-01T16:21:33Z","peer_id":"MLF0jAGTpL84LLerLddNs5M10NCHM+BwNeMxK78+"}`
 const TSPG_EXPECTED_2 = `{"block":"zLgvHQzxSh8MWlTjXK+cMA==","created_at":"2021-07-01T16:21:33Z","peer_id":"MLF0jAGTpL84LLerLddNs5M10NCHM+BwNeMxK78+","snark_work":"Bjtox/3Yu4cT5eVCQz/JQ+P3Ce1JmCIE7N6b1MAa"}`
+
+func setNetworkEnvVar() {
+	err := os.Setenv("NETWORK", "mainnet")
+	if err != nil {
+		panic(err)
+	}
+}
 
 func mkB64(s string) *Base64 {
 	r := new(Base64)
@@ -142,6 +150,7 @@ func TestUnauthorized(t *testing.T) {
 }
 
 func TestPkLimitExceeded(t *testing.T) {
+	setNetworkEnvVar()
 	body := readTestFile("req-with-snark", t)
 	var req submitRequest
 	if err := json.Unmarshal(body, &req); err != nil {
@@ -174,6 +183,7 @@ func TestPkLimitExceeded(t *testing.T) {
 }
 
 func TestSuccess(t *testing.T) {
+	setNetworkEnvVar()
 	testNames := []string{"req-no-snark", "req-with-snark"}
 	for _, f := range testNames {
 		body := readTestFile(f, t)


### PR DESCRIPTION
So, there were some tests failing:
```
$ make test
GO=go ./scripts/build.sh test
--- FAIL: TestPkLimitExceeded (0.00s)
    submit_test.go:155: Unexpected failure: &{401 map[] {"error":"Invalid signature"} false <nil> map[] true}
--- FAIL: TestSuccess (0.00s)
    submit_test.go:188: Failed testing req-no-snark: &{401 map[] {"error":"Invalid signature"} false <nil> map[] true}
FAIL
exit status 1
FAIL    block_producers_uptime/delegation_backend       0.502s
make: *** [Makefile:17: test] Error 1
```

Through `git bisect` I found the culprit commit:
 - https://github.com/MinaProtocol/mina/pull/13039/commits/628d345f65b9174ee02df64e8bebbce8a3615db2

This PR fixes the tests however I'm not sure if this is the way to go. Anyway, with the change the tests pass:

```
$ make test
GO=go ./scripts/build.sh test
PASS
ok      block_producers_uptime/delegation_backend       0.474s
```