### PR TITLE
PM-646 - Aws keyspaces connection: use LoadDefaultConfig, when initializing connection

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: minafoundation-default-runners
+    runs-on: ubuntu-latest
   
     steps:
     - name: 📥 Checkout

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -44,3 +44,21 @@ jobs:
         # UPTIME_SERVICE_SECRET is a passphrase needed to decrypt uptime service config files
         UPTIME_SERVICE_SECRET: ${{ secrets.UPTIME_SERVICE_SECRET }}
       run: nix-shell --run "make integration-test"
+
+    - name: 📖 Get logs
+      if: always()
+      run: |
+        mkdir -p integration-test/logs
+        minimina network list
+        minimina network status -n integration-test
+        minimina node logs -n integration-test -i uptime-service-backend -r > integration-test/logs/uptime-service-backend.log
+        minimina node logs -n integration-test -i node-a -r > integration-test/logs/node-a.log
+        minimina node logs -n integration-test -i node-b -r > integration-test/logs/node-b.log
+        minimina node logs -n integration-test -i node-c -r > integration-test/logs/node-c.log
+
+    - name: 📎 Upload logs
+      uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: logs
+        path: integration-test/logs

--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ If the `CONFIG_FILE` environment variable is not set, the program will fall back
    - `AWS_SECRET_ACCESS_KEY` - Your AWS Secret Access Key (same as used for S3).
    - `AWS_SSL_CERTIFICATE_PATH` - The path to your SSL certificate for AWS Keyspaces.
 
+> **Note:** Docker image already includes cert and has `AWS_SSL_CERTIFICATE_PATH` set up, however it can be overriden by providing this env variable to docker.
+
 5. **Local File System Configuration**:
    - `CONFIG_FILESYSTEM_PATH` - Set this to the path where you want the local file system to point.
 
@@ -168,7 +170,6 @@ docker run \
 --entrypoint db_migration \
 673156464838.dkr.ecr.us-west-2.amazonaws.com/block-producers-uptime:$TAG down
 ```
-> **Note:** Docker image already includes cert and has `AWS_SSL_CERTIFICATE_PATH` set up, however it can be overriden by providing this env variable to docker.
 
 Once you have set up your configuration using either a JSON file or environment variables, you can proceed to run the program. The program will automatically load the configuration and initialize based on the provided settings.
 

--- a/README.md
+++ b/README.md
@@ -102,10 +102,11 @@ If the `CONFIG_FILE` environment variable is not set, the program will fall back
    - `CONFIG_NETWORK_NAME` - Set this to your network name.
 
 2. **Whitelist Configuration**:
+   - `GOOGLE_APPLICATION_CREDENTIALS` - set path to `minasheets.json` file including credentials to connect to Google Sheets.
    - `CONFIG_GSHEET_ID` - Set this to your Google Sheet ID with the keys to whitelist.
    - `DELEGATION_WHITELIST_LIST` - Set this to your delegation whitelist sheet title where the whitelist keys are.
    - `DELEGATION_WHITELIST_COLUMN` - Set this to your delegation whitelist sheet column where the whitelist keys are.
-   -  Or disable whitelisting alltogether by setting `DELEGATION_WHITELIST_DISABLED=1`. The previous three env variables are then ignored.
+   -  Or disable whitelisting alltogether by setting `DELEGATION_WHITELIST_DISABLED=1`. The previous four env variables are then ignored.
 
 3. **AWS S3 Configuration**:
    - `AWS_ACCOUNT_ID` - Your AWS Account ID.

--- a/src/cmd/db_migration/main.go
+++ b/src/cmd/db_migration/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	dg "block_producers_uptime/delegation_backend"
+	"context"
 	"os"
 
 	logging "github.com/ipfs/go-log/v2"
@@ -21,6 +22,7 @@ func main() {
 	log := logging.Logger("delegation backend db migration")
 
 	config := dg.LoadEnv(log)
+	ctx := context.Background()
 
 	if len(os.Args) < 2 {
 		log.Fatal("Missing required command: 'up' or 'down'")
@@ -30,12 +32,12 @@ func main() {
 		log.Infof("storage backend: Aws Keyspaces")
 		switch os.Args[1] {
 		case "up":
-			err := dg.MigrationUp(config.AwsKeyspaces, DATABASE_MIGRATION_DIR)
+			err := dg.MigrationUp(ctx, config.AwsKeyspaces, DATABASE_MIGRATION_DIR)
 			if err != nil {
 				log.Fatalf("Migration up failed: %v", err)
 			}
 		case "down":
-			err := dg.MigrationDown(config.AwsKeyspaces, DATABASE_MIGRATION_DIR)
+			err := dg.MigrationDown(ctx, config.AwsKeyspaces, DATABASE_MIGRATION_DIR)
 			if err != nil {
 				log.Fatalf("Migration down failed: %v", err)
 			}

--- a/src/cmd/delegation_backend/main_bpu.go
+++ b/src/cmd/delegation_backend/main_bpu.go
@@ -51,7 +51,7 @@ func main() {
 		}
 	} else if appCfg.AwsKeyspaces != nil {
 		log.Infof("storage backend: Aws Keyspaces")
-		session, err := InitializeKeyspaceSession(appCfg.AwsKeyspaces)
+		session, err := InitializeKeyspaceSession(ctx, appCfg.AwsKeyspaces)
 		if err != nil {
 			log.Fatalf("Error initializing Keyspace session: %v", err)
 		}

--- a/src/delegation_backend/app_config.go
+++ b/src/delegation_backend/app_config.go
@@ -33,7 +33,11 @@ func LoadEnv(log logging.EventLogger) AppConfig {
 		if config.Aws != nil {
 			os.Setenv("AWS_ACCESS_KEY_ID", config.Aws.AccessKeyId)
 			os.Setenv("AWS_SECRET_ACCESS_KEY", config.Aws.SecretAccessKey)
+		} else if config.AwsKeyspaces != nil {
+			os.Setenv("AWS_ACCESS_KEY_ID", config.AwsKeyspaces.AccessKeyId)
+			os.Setenv("AWS_SECRET_ACCESS_KEY", config.AwsKeyspaces.SecretAccessKey)
 		}
+
 	} else {
 		networkName := getEnvChecked("CONFIG_NETWORK_NAME", log)
 

--- a/src/delegation_backend/app_config.go
+++ b/src/delegation_backend/app_config.go
@@ -53,10 +53,11 @@ func LoadEnv(log logging.EventLogger) AppConfig {
 			delegationWhitelistColumn = getEnvChecked("DELEGATION_WHITELIST_COLUMN", log)
 		}
 
-		// AWS configurations
+		// AWS S3 configurations
 		if bucketNameSuffix := os.Getenv("AWS_BUCKET_NAME_SUFFIX"); bucketNameSuffix != "" {
-			accessKeyId := getEnvChecked("AWS_ACCESS_KEY_ID", log)
-			secretAccessKey := getEnvChecked("AWS_SECRET_ACCESS_KEY", log)
+			// accessKeyId and secretAccessKey variables are not needed if program works in k8s cluster
+			accessKeyId := os.Getenv("AWS_ACCESS_KEY_ID")
+			secretAccessKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
 			awsRegion := getEnvChecked("AWS_REGION", log)
 			awsAccountId := getEnvChecked("AWS_ACCOUNT_ID", log)
 			bucketNameSuffix := getEnvChecked("AWS_BUCKET_NAME_SUFFIX", log)
@@ -72,8 +73,9 @@ func LoadEnv(log logging.EventLogger) AppConfig {
 
 		// AWSKeyspace configurations
 		if awsKeyspace := os.Getenv("AWS_KEYSPACE"); awsKeyspace != "" {
-			accessKeyId := getEnvChecked("AWS_ACCESS_KEY_ID", log)
-			secretAccessKey := getEnvChecked("AWS_SECRET_ACCESS_KEY", log)
+			// accessKeyId and secretAccessKey variables are not needed if program works in k8s cluster
+			accessKeyId := os.Getenv("AWS_ACCESS_KEY_ID")
+			secretAccessKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
 			awsRegion := getEnvChecked("AWS_REGION", log)
 			awsKeyspace := getEnvChecked("AWS_KEYSPACE", log)
 			sslCertificatePath := getEnvChecked("AWS_SSL_CERTIFICATE_PATH", log)

--- a/src/integration_tests/aws_helper.go
+++ b/src/integration_tests/aws_helper.go
@@ -26,6 +26,14 @@ func getAppConfig() delegation_backend.AppConfig {
 	if err := json.Unmarshal(appConfigBytes, &config); err != nil {
 		log.Fatalf("Failed to parse app_config.json: %v", err)
 	}
+	// Set AWS credentials from config file in case we are using AWS S3 or AWS Keyspaces
+	if config.Aws != nil {
+		os.Setenv("AWS_ACCESS_KEY_ID", config.Aws.AccessKeyId)
+		os.Setenv("AWS_SECRET_ACCESS_KEY", config.Aws.SecretAccessKey)
+	} else if config.AwsKeyspaces != nil {
+		os.Setenv("AWS_ACCESS_KEY_ID", config.AwsKeyspaces.AccessKeyId)
+		os.Setenv("AWS_SECRET_ACCESS_KEY", config.AwsKeyspaces.SecretAccessKey)
+	}
 
 	return config
 }

--- a/src/integration_tests/aws_keyspaces_helper.go
+++ b/src/integration_tests/aws_keyspaces_helper.go
@@ -2,6 +2,7 @@ package integration_tests
 
 import (
 	dg "block_producers_uptime/delegation_backend"
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -35,10 +36,10 @@ func checkForSubmissions(session *gocql.Session, keyspace, date string) (bool, e
 	return true, nil // At least one submission found for today
 }
 
-func waitUntilKeyspacesHasBlocksAndSubmissions(config dg.AppConfig) error {
+func waitUntilKeyspacesHasBlocksAndSubmissions(ctx context.Context, config dg.AppConfig) error {
 	log.Printf("Waiting for blocks and submissions to appear in Keyspaces")
 
-	sess, err := dg.InitializeKeyspaceSession(config.AwsKeyspaces)
+	sess, err := dg.InitializeKeyspaceSession(ctx, config.AwsKeyspaces)
 	if err != nil {
 		return fmt.Errorf("error initializing Keyspace session: %w", err)
 	}
@@ -72,9 +73,9 @@ func waitUntilKeyspacesHasBlocksAndSubmissions(config dg.AppConfig) error {
 	}
 }
 
-func WaitForTablesActive(config *dg.AwsKeyspacesConfig, tables []string) error {
+func WaitForTablesActive(ctx context.Context, config *dg.AwsKeyspacesConfig, tables []string) error {
 	log.Printf("Waiting for tables %v to be active...", tables)
-	session, err := dg.InitializeKeyspaceSession(config)
+	session, err := dg.InitializeKeyspaceSession(ctx, config)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In K8s context aws credentials are retrieved from the profile. Using LoadDefaultConfig to hopefully account for that. AWS S3 connection has been using that, so it should work for AWS Keyspace too. :crossed_fingers: 