### PR TITLE
PM-1065 - Check if block exists on S3Save  - delegation backend performance improvement.

### DIFF
--- a/src/delegation_backend/submit.go
+++ b/src/delegation_backend/submit.go
@@ -36,17 +36,23 @@ func writeErrorResponse(app *App, w *http.ResponseWriter, msg string) {
 
 func (ctx *AwsContext) S3Save(objs ObjectsToSave) {
 	for path, bs := range objs {
-		_, err := ctx.Client.HeadObject(ctx.Context, &s3.HeadObjectInput{
-			Bucket: ctx.BucketName,
-			Key:    aws.String(ctx.Prefix + "/" + path),
-		})
-		if err == nil {
-			ctx.Log.Warnf("S3Save: object already exists: %s", path)
+		fullKey := aws.String(ctx.Prefix + "/" + path)
+		if strings.Contains(path, "blocks") {
+			_, err := ctx.Client.HeadObject(ctx.Context, &s3.HeadObjectInput{
+				Bucket: ctx.BucketName,
+				Key:    fullKey,
+			})
+			if err == nil {
+				ctx.Log.Warnf("S3Save: object already exists, skipping: %s", path)
+				continue
+			}
+			ctx.Log.Warnf("S3Save: Error encountered but proceeding with save: %s, error: %v", path, err)
 		}
+
 		ctx.Log.Debugf("S3Save: saving %s", path)
-		_, err = ctx.Client.PutObject(ctx.Context, &s3.PutObjectInput{
+		_, err := ctx.Client.PutObject(ctx.Context, &s3.PutObjectInput{
 			Bucket:     ctx.BucketName,
-			Key:        aws.String(ctx.Prefix + "/" + path),
+			Key:        fullKey,
 			Body:       bytes.NewReader(bs),
 			ContentMD5: nil,
 		})

--- a/src/delegation_backend/submit.go
+++ b/src/delegation_backend/submit.go
@@ -37,16 +37,18 @@ func writeErrorResponse(app *App, w *http.ResponseWriter, msg string) {
 func (ctx *AwsContext) S3Save(objs ObjectsToSave) {
 	for path, bs := range objs {
 		fullKey := aws.String(ctx.Prefix + "/" + path)
-		if strings.Contains(path, "blocks") {
+		if strings.HasPrefix(path, "blocks/") {
 			_, err := ctx.Client.HeadObject(ctx.Context, &s3.HeadObjectInput{
 				Bucket: ctx.BucketName,
 				Key:    fullKey,
 			})
 			if err == nil {
-				ctx.Log.Warnf("S3Save: object already exists, skipping: %s", path)
+				//block already exists, skipping
 				continue
 			}
-			ctx.Log.Warnf("S3Save: Error encountered but proceeding with save: %s, error: %v", path, err)
+			if !strings.Contains(err.Error(), "NotFound") {
+				ctx.Log.Warnf("S3Save: Error when checking if block exists, but will continue with block save: %s, error: %v", path, err)
+			}
 		}
 
 		ctx.Log.Debugf("S3Save: saving %s", path)


### PR DESCRIPTION
Explain your changes:

Prior the change there was a check in S3Save if particular item (submission or block) already exists on S3, however whether it existed or not, the item was overwritten anyway. The change only checks whether block exists, and if it does, it skips writing it to S3. I believe that the same check for the submission is not needed as it has a timestamp in the 'filename' so it will be always different.

Explain how you tested your changes:

This change seem to significantly improve response times and memory usage of the application.
Load test has been performed prior and after applying the fix. Results gathered in the report: https://github.com/MinaFoundation/mina-delegation-program-tech/wiki/Load-Test-Report-2024%E2%80%9001%E2%80%9018