### PR TITLE
PM-1111 Configurable requests per pk hourly

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ As part of delegation program, nodes are to upload some proof of their activity.
 ## Constants
 
 - `MAX_SUBMIT_PAYLOAD_SIZE` : max size (in bytes) of the `POST /submit` payload
-- `REQUESTS_PER_IP_HOURLY` : max amount of requests per hour per  IP address
 - `REQUESTS_PER_PK_HOURLY` : max amount of requests per hour per public key `submitter` [default: 120, can be overriden by setting `REQUESTS_PER_PK_HOURLY` env variable].
 
 ## Protocol

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ As part of delegation program, nodes are to upload some proof of their activity.
 
 - `MAX_SUBMIT_PAYLOAD_SIZE` : max size (in bytes) of the `POST /submit` payload
 - `REQUESTS_PER_IP_HOURLY` : max amount of requests per hour per  IP address
-- `REQUESTS_PER_PK_HOURLY` : max amount of requests per hour per public key `submitter`
+- `REQUESTS_PER_PK_HOURLY` : max amount of requests per hour per public key `submitter` [default: 120, can be overriden by setting `REQUESTS_PER_PK_HOURLY` env variable].
 
 ## Protocol
 

--- a/src/cmd/delegation_backend/main_bpu.go
+++ b/src/cmd/delegation_backend/main_bpu.go
@@ -4,8 +4,6 @@ import (
 	. "block_producers_uptime/delegation_backend"
 	"context"
 	"net/http"
-	"os"
-	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -15,23 +13,6 @@ import (
 	"google.golang.org/api/option"
 	sheets "google.golang.org/api/sheets/v4"
 )
-
-var requestsPerPkHourly int
-
-func init() {
-	var defaultValue = 120
-	var err error
-
-	envVarValue, exists := os.LookupEnv("REQUESTS_PER_PK_HOURLY")
-	if exists {
-		requestsPerPkHourly, err = strconv.Atoi(envVarValue)
-		if err != nil {
-			requestsPerPkHourly = defaultValue
-		}
-	} else {
-		requestsPerPkHourly = defaultValue
-	}
-}
 
 func main() {
 	// Setup logging
@@ -104,6 +85,7 @@ func main() {
 
 	// App other configurations
 	app.Now = func() time.Time { return time.Now() }
+	requestsPerPkHourly := SetRequestsPerPkHourly(log)
 	app.SubmitCounter = NewAttemptCounter(requestsPerPkHourly)
 	log.Infof("Max requests per pk hourly: %v", requestsPerPkHourly)
 

--- a/src/cmd/delegation_backend/main_bpu.go
+++ b/src/cmd/delegation_backend/main_bpu.go
@@ -4,6 +4,8 @@ import (
 	. "block_producers_uptime/delegation_backend"
 	"context"
 	"net/http"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -13,6 +15,23 @@ import (
 	"google.golang.org/api/option"
 	sheets "google.golang.org/api/sheets/v4"
 )
+
+var requestsPerPkHourly int
+
+func init() {
+	var defaultValue = 120
+	var err error
+
+	envVarValue, exists := os.LookupEnv("REQUESTS_PER_PK_HOURLY")
+	if exists {
+		requestsPerPkHourly, err = strconv.Atoi(envVarValue)
+		if err != nil {
+			requestsPerPkHourly = defaultValue
+		}
+	} else {
+		requestsPerPkHourly = defaultValue
+	}
+}
 
 func main() {
 	// Setup logging
@@ -85,7 +104,8 @@ func main() {
 
 	// App other configurations
 	app.Now = func() time.Time { return time.Now() }
-	app.SubmitCounter = NewAttemptCounter(REQUESTS_PER_PK_HOURLY)
+	app.SubmitCounter = NewAttemptCounter(requestsPerPkHourly)
+	log.Infof("Max requests per pk hourly: %v", requestsPerPkHourly)
 
 	// HTTP handlers setup
 	http.HandleFunc("/", func(rw http.ResponseWriter, r *http.Request) {

--- a/src/delegation_backend/constants.go
+++ b/src/delegation_backend/constants.go
@@ -2,7 +2,10 @@ package delegation_backend
 
 import (
 	"os"
+	"strconv"
 	"time"
+
+	logging "github.com/ipfs/go-log/v2"
 )
 
 const MAX_SUBMIT_PAYLOAD_SIZE = 50000000 // max payload size in bytes
@@ -19,6 +22,24 @@ func NetworkId() uint8 {
 		return 1
 	}
 	return 0
+}
+
+func SetRequestsPerPkHourly(log logging.StandardLogger) int {
+	var defaultValue = 120
+	var requestsPerPkHourly int
+	var err error
+
+	envVarValue, exists := os.LookupEnv("REQUESTS_PER_PK_HOURLY")
+	if exists {
+		requestsPerPkHourly, err = strconv.Atoi(envVarValue)
+		if err != nil {
+			log.Warnf("Error parsing REQUESTS_PER_PK_HOURLY, falling back to default value: %v, error: %v", defaultValue, err)
+			requestsPerPkHourly = defaultValue
+		}
+	} else {
+		requestsPerPkHourly = defaultValue
+	}
+	return requestsPerPkHourly
 }
 
 const PK_LENGTH = 33  // one field element (32B) + 1 bit (encoded as full byte)

--- a/src/delegation_backend/constants.go
+++ b/src/delegation_backend/constants.go
@@ -6,7 +6,6 @@ import (
 )
 
 const MAX_SUBMIT_PAYLOAD_SIZE = 50000000 // max payload size in bytes
-const REQUESTS_PER_PK_HOURLY = 120
 const DELEGATION_BACKEND_LISTEN_TO = ":8080"
 const TIME_DIFF_DELTA time.Duration = -5 * 60 * 1000000000 // -5m
 const WHITELIST_REFRESH_INTERVAL = 10 * 60 * 1000000000    // 10m


### PR DESCRIPTION
This change enables configuring requests per pk hourly by setting env variable `REQUESTS_PER_PK_HOURLY`. It may be particularly useful when performing load testing.