### PR TITLE
PM-1134 add tests for ExponentialBackoff

### DIFF
--- a/dockerfiles/Dockerfile-delegation-backend
+++ b/dockerfiles/Dockerfile-delegation-backend
@@ -1,4 +1,4 @@
-FROM golang:1.18
+FROM golang:1.20
 
 # Set the Current Working Directory inside the container
 WORKDIR $GOPATH/src/delegation_backend

--- a/shell.nix
+++ b/shell.nix
@@ -5,7 +5,7 @@ in
 {
   devEnv = stdenv.mkDerivation {
     name = "dev";
-    buildInputs = [ stdenv go_1_19 glibc minaSigner ];
+    buildInputs = [ stdenv go_1_20 glibc minaSigner ];
     shellHook = ''
       export LIB_MINA_SIGNER=${minaSigner}/lib/libmina_signer.so
       return

--- a/src/delegation_backend/operation_test.go
+++ b/src/delegation_backend/operation_test.go
@@ -1,0 +1,71 @@
+package delegation_backend
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestExponentialBackoff(t *testing.T) {
+
+	var mockOperationCalls int
+
+	// Test cases
+	testCases := []struct {
+		name                   string
+		operation              Operation
+		expectedOperationCalls int
+		shouldError            bool
+	}{
+		{
+			name: "TC 1: Success on first attempt",
+			operation: func() error {
+				mockOperationCalls++
+				return nil // Success on first attempt
+			},
+			expectedOperationCalls: 1,
+			shouldError:            false,
+		},
+		{
+			name: "TC 2: Success on second attempt",
+			operation: func() error {
+				mockOperationCalls++
+				if mockOperationCalls < 2 {
+					return errors.New("temporary error")
+				}
+				return nil // Success on second attempt
+			},
+			expectedOperationCalls: 2,
+			shouldError:            false,
+		},
+		{
+			name: "TC 3: Fails after 3 attempts",
+			operation: func() error {
+				mockOperationCalls++
+				return errors.New("persistent error")
+			},
+			expectedOperationCalls: 3,
+			shouldError:            true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Reset operation call count
+			mockOperationCalls = 0
+
+			// Run the ExponentialBackoff function
+			err := ExponentialBackoff(tc.operation, 3, 10*time.Millisecond)
+
+			// Check if error matches expectation
+			if (err != nil) != tc.shouldError {
+				t.Errorf("%s: Expected error: %v, got: %v", tc.name, tc.shouldError, err != nil)
+			}
+
+			// Assertions for operation call count
+			if mockOperationCalls != tc.expectedOperationCalls {
+				t.Errorf("%s: Expected %d operation calls, got %d", tc.name, tc.expectedOperationCalls, mockOperationCalls)
+			}
+		})
+	}
+}

--- a/src/delegation_backend/sheets.go
+++ b/src/delegation_backend/sheets.go
@@ -44,7 +44,7 @@ func RetrieveWhitelist(service *sheets.Service, log *logging.ZapEventLogger, app
 	retries := 10
 	err = ExponentialBackoff(operation, retries, initialBackoff)
 	if err != nil {
-		log.Fatalf("Unable to retrieve data from sheet after %v retries: %v", retries, err)
+		log.Errorf("Unable to retrieve data from sheet after %v retries: %v", retries, err)
 	}
 
 	return processRows(resp.Values)


### PR DESCRIPTION
Just porting tests for ExponentialBackoff (+ few other changes) from https://github.com/MinaFoundation/uptime-service-backend-legacy/pull/1.