### PR TITLE
PM-1343 Caclulate block size

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -5,7 +5,7 @@ in
 {
   devEnv = stdenv.mkDerivation {
     name = "dev";
-    buildInputs = [ stdenv go_1_20 glibc minaSigner ];
+    buildInputs = [ stdenv go_1_21 glibc minaSigner ];
     shellHook = ''
       export LIB_MINA_SIGNER=${minaSigner}/lib/libmina_signer.so
       return

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-with import <nixpkgs> { };
+with import (fetchTarball "https://nixos.org/channels/nixos-unstable/nixexprs.tar.xz") { };
 let
   minaSigner = import ./external/c-reference-signer;
 in

--- a/src/delegation_backend/aws_keyspaces.go
+++ b/src/delegation_backend/aws_keyspaces.go
@@ -206,7 +206,12 @@ func calculateBlockSize(rawBlock []byte) int {
 // Insert a submission into the Keyspaces database
 func (kc *KeyspaceContext) insertSubmission(submission *Submission) error {
 	return ExponentialBackoff(func() error {
-		if submission.RawBlock != nil && calculateBlockSize(submission.RawBlock) > MAX_BLOCK_SIZE {
+		if submission.RawBlock == nil {
+			kc.Log.Error("KeyspaceSave: Block is missing in the submission, which is not expected, but inserting without raw_block")
+			if err := kc.insertSubmissionWithoutRawBlock(submission); err != nil {
+				return err
+			}
+		} else if calculateBlockSize(submission.RawBlock) > MAX_BLOCK_SIZE {
 			kc.Log.Infof("KeyspaceSave: Block too large (%d bytes), inserting without raw_block", calculateBlockSize(submission.RawBlock))
 			if err := kc.insertSubmissionWithoutRawBlock(submission); err != nil {
 				return err

--- a/src/delegation_backend/aws_keyspaces.go
+++ b/src/delegation_backend/aws_keyspaces.go
@@ -207,7 +207,7 @@ func calculateBlockSize(rawBlock []byte) int {
 func (kc *KeyspaceContext) insertSubmission(submission *Submission) error {
 	return ExponentialBackoff(func() error {
 		if submission.RawBlock != nil && calculateBlockSize(submission.RawBlock) > MAX_BLOCK_SIZE {
-			kc.Log.Warnf("KeyspaceSave: Block too large (%d bytes), inserting without raw_block", calculateBlockSize(submission.RawBlock))
+			kc.Log.Infof("KeyspaceSave: Block too large (%d bytes), inserting without raw_block", calculateBlockSize(submission.RawBlock))
 			if err := kc.insertSubmissionWithoutRawBlock(submission); err != nil {
 				return err
 			}
@@ -266,7 +266,7 @@ func (kc *KeyspaceContext) KeyspaceSave(objs ObjectsToSave) {
 		if strings.HasPrefix(path, "submissions/") {
 			submission, err := kc.parseSubmissionBytes(bs, path)
 			if err != nil {
-				kc.Log.Warnf("KeyspaceSave: Error parsing submission JSON: %v", err)
+				kc.Log.Errorf("KeyspaceSave: Error parsing submission JSON: %v", err)
 				continue
 			}
 			submissionToSave.BlockHash = submission.BlockHash
@@ -283,17 +283,17 @@ func (kc *KeyspaceContext) KeyspaceSave(objs ObjectsToSave) {
 		} else if strings.HasPrefix(path, "blocks/") {
 			block, err := kc.parseBlockBytes(bs, path)
 			if err != nil {
-				kc.Log.Warnf("KeyspaceSave: Error parsing block file: %v", err)
+				kc.Log.Errorf("KeyspaceSave: Error parsing block file: %v", err)
 				continue
 			}
 			submissionToSave.RawBlock = block.RawBlock
 			submissionToSave.BlockHash = block.BlockHash
 		} else {
-			kc.Log.Warnf("KeyspaceSave: Unknown path format: %s", path)
+			kc.Log.Errorf("KeyspaceSave: Unknown path format: %s", path)
 		}
 
 	}
-	kc.Log.Debugf("KeyspaceSave: Saving submission for block: %v, submitter: %v, submitted_at: %v", submissionToSave.BlockHash, submissionToSave.Submitter, submissionToSave.SubmittedAt)
+	kc.Log.Infof("KeyspaceSave: Saving submission for block: %v, submitter: %v, submitted_at: %v", submissionToSave.BlockHash, submissionToSave.Submitter, submissionToSave.SubmittedAt)
 	if err := kc.insertSubmission(submissionToSave); err != nil {
 		kc.Log.Errorf("KeyspaceSave: Error saving submission to Keyspaces: %v", err)
 	}

--- a/src/delegation_backend/aws_keyspaces.go
+++ b/src/delegation_backend/aws_keyspaces.go
@@ -295,7 +295,7 @@ func (kc *KeyspaceContext) KeyspaceSave(objs ObjectsToSave) {
 	}
 	kc.Log.Debugf("KeyspaceSave: Saving submission for block: %v, submitter: %v, submitted_at: %v", submissionToSave.BlockHash, submissionToSave.Submitter, submissionToSave.SubmittedAt)
 	if err := kc.insertSubmission(submissionToSave); err != nil {
-		kc.Log.Warnf("KeyspaceSave: Error saving submission to Keyspaces: %v", err)
+		kc.Log.Errorf("KeyspaceSave: Error saving submission to Keyspaces: %v", err)
 	}
 }
 

--- a/src/delegation_backend/constants.go
+++ b/src/delegation_backend/constants.go
@@ -16,6 +16,7 @@ const WHITELIST_REFRESH_INTERVAL = 10 * 60 * 1000000000    // 10m
 var PK_PREFIX = [...]byte{1, 1}
 var SIG_PREFIX = [...]byte{1}
 var BLOCK_HASH_PREFIX = [...]byte{1}
+var MAX_BLOCK_SIZE = 1000000 // (1MB) max block size in bytes for Cassandra, blocks larger than this size will be stored in S3 only
 
 func NetworkId() uint8 {
 	if os.Getenv("NETWORK") == "mainnet" {

--- a/src/delegation_backend/submit.go
+++ b/src/delegation_backend/submit.go
@@ -51,7 +51,7 @@ func (ctx *AwsContext) S3Save(objs ObjectsToSave) {
 			}
 		}
 
-		ctx.Log.Debugf("S3Save: saving %s", path)
+		ctx.Log.Infof("S3Save: saving %s", path)
 		_, err := ctx.Client.PutObject(ctx.Context, &s3.PutObjectInput{
 			Bucket:     ctx.BucketName,
 			Key:        fullKey,
@@ -76,10 +76,10 @@ func LocalFileSystemSave(objs ObjectsToSave, directory string, log logging.Stand
 
 		err := os.MkdirAll(filepath.Dir(fullPath), os.ModePerm)
 		if err != nil {
-			log.Warnf("LocalFileSystemSave: Error creating directories for %s: %v", fullPath, err)
+			log.Errorf("LocalFileSystemSave: Error creating directories for %s: %v", fullPath, err)
 			continue // skip to the next object
 		}
-		log.Debugf("LocalFileSystemSave: saving %s", fullPath)
+		log.Infof("LocalFileSystemSave: saving %s", fullPath)
 		err = os.WriteFile(fullPath, bs, 0644)
 		if err != nil {
 			log.Warnf("Error writing to file %s: %v", fullPath, err)


### PR DESCRIPTION
This pull request introduces a proactive check on block sizes before insertion into Cassandra for Keyspaces, due to a 1MB row size limit. Previously, submissions were inserted blindly, and only upon exceeding the limit, the raw_block was omitted in a retry. Load tests indicated that this reactive approach caused request backlogs and resource issues due to delayed Keyspaces responses. Now, we preemptively exclude blocks over 1,000 bytes (slightly under 1MB to accommodate for other fields) from insertion. This optimization significantly enhances system robustness.