### PR TITLE
PM-1547 clear usage of CONFIG_NETWORK_NAME env var

### DIFF
--- a/src/cmd/delegation_backend/main_bpu.go
+++ b/src/cmd/delegation_backend/main_bpu.go
@@ -37,6 +37,7 @@ func main() {
 	if app.VerifySignatureDisabled {
 		log.Warnf("Signature verification is disabled, it is not recommended to run the delegation backend in this mode!")
 	}
+	app.NetworkId = NetworkId(appCfg.NetworkName)
 
 	// Storage backend setup
 	if appCfg.Aws != nil {

--- a/src/delegation_backend/app_config.go
+++ b/src/delegation_backend/app_config.go
@@ -36,6 +36,8 @@ func LoadEnv(log logging.EventLogger) AppConfig {
 			os.Setenv("AWS_SECRET_ACCESS_KEY", config.Aws.SecretAccessKey)
 		}
 	} else {
+		// networkName is used as part of the S3 bucket path and influences networkId
+		// networkName = "mainnet" will result in networkId = 1 else networkId = 0 and this influeces verifySignature
 		networkName := getEnvChecked("CONFIG_NETWORK_NAME", log)
 		verifySignatureDisabled := boolEnvChecked("VERIFY_SIGNATURE_DISABLED", log)
 

--- a/src/delegation_backend/constants.go
+++ b/src/delegation_backend/constants.go
@@ -18,8 +18,8 @@ var SIG_PREFIX = [...]byte{1}
 var BLOCK_HASH_PREFIX = [...]byte{1}
 var MAX_BLOCK_SIZE = 1000000 // (1MB) max block size in bytes for Cassandra, blocks larger than this size will be stored in S3 only
 
-func NetworkId() uint8 {
-	if os.Getenv("NETWORK") == "mainnet" {
+func NetworkId(networkName string) uint8 {
+	if networkName == "mainnet" {
 		return 1
 	}
 	return 0

--- a/src/delegation_backend/submit.go
+++ b/src/delegation_backend/submit.go
@@ -103,6 +103,7 @@ type App struct {
 	Whitelist               *WhitelistMVar
 	WhitelistDisabled       bool
 	VerifySignatureDisabled bool
+	NetworkId               uint8
 	Save                    func(ObjectsToSave)
 	Now                     nowFunc
 }
@@ -189,7 +190,7 @@ func (h *SubmitH) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		hash := blake2b.Sum256(payload)
-		if !verifySig(&req.Submitter, &req.Sig, hash[:], NetworkId()) {
+		if !verifySig(&req.Submitter, &req.Sig, hash[:], h.app.NetworkId) {
 			w.WriteHeader(401)
 			writeErrorResponse(h.app, &w, "Invalid signature")
 			return

--- a/src/delegation_backend/submit_test.go
+++ b/src/delegation_backend/submit_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
-	"io/ioutil"
 	"math/rand"
 	"net/http/httptest"
 	"os"
@@ -16,13 +15,6 @@ import (
 
 const TSPG_EXPECTED_1 = `{"block":"zLgvHQzxSh8MWlTjXK+cMA==","created_at":"2021-07-01T16:21:33Z","peer_id":"MLF0jAGTpL84LLerLddNs5M10NCHM+BwNeMxK78+"}`
 const TSPG_EXPECTED_2 = `{"block":"zLgvHQzxSh8MWlTjXK+cMA==","created_at":"2021-07-01T16:21:33Z","peer_id":"MLF0jAGTpL84LLerLddNs5M10NCHM+BwNeMxK78+","snark_work":"Bjtox/3Yu4cT5eVCQz/JQ+P3Ce1JmCIE7N6b1MAa"}`
-
-func setNetworkEnvVar() {
-	err := os.Setenv("NETWORK", "mainnet")
-	if err != nil {
-		panic(err)
-	}
-}
 
 func mkB64(s string) *Base64 {
 	r := new(Base64)
@@ -70,6 +62,7 @@ func testSubmitH(maxAttempt int, initWl Whitelist) (*ObjectsToSave, *SubmitH, *t
 	wlMvar := new(WhitelistMVar)
 	wlMvar.Replace(&initWl)
 	app.Whitelist = wlMvar
+	app.NetworkId = 1
 	return &storage, app.NewSubmitH(), tm
 }
 
@@ -83,7 +76,7 @@ func (sh *SubmitH) testRequest(body []byte) *httptest.ResponseRecorder {
 }
 
 func readTestFile(n string, t *testing.T) []byte {
-	body, err := ioutil.ReadFile("../../test/data/" + n + ".json")
+	body, err := os.ReadFile("../../test/data/" + n + ".json")
 	if err != nil {
 		t.Log("can not read test file")
 		t.FailNow()
@@ -150,7 +143,6 @@ func TestUnauthorized(t *testing.T) {
 }
 
 func TestPkLimitExceeded(t *testing.T) {
-	setNetworkEnvVar()
 	body := readTestFile("req-with-snark", t)
 	var req submitRequest
 	if err := json.Unmarshal(body, &req); err != nil {
@@ -183,7 +175,6 @@ func TestPkLimitExceeded(t *testing.T) {
 }
 
 func TestSuccess(t *testing.T) {
-	setNetworkEnvVar()
 	testNames := []string{"req-no-snark", "req-with-snark"}
 	for _, f := range testNames {
 		body := readTestFile(f, t)


### PR DESCRIPTION
use only `CONFIG_NETWORK_NAME` to set the network name. This env var influences network id and also is part of s3 bucket path.