### PR TITLE
PM-1779 Don`t crash when whitelist unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ If the `CONFIG_FILE` environment variable is not set, the program will fall back
    - `CONFIG_GSHEET_ID` - Set this to your Google Sheet ID with the keys to whitelist.
    - `DELEGATION_WHITELIST_LIST` - Set this to your delegation whitelist sheet title where the whitelist keys are.
    - `DELEGATION_WHITELIST_COLUMN` - Set this to your delegation whitelist sheet column where the whitelist keys are.
-   -  Or disable whitelisting alltogether by setting `DELEGATION_WHITELIST_DISABLED=1`. The previous four env variables are then ignored.
+   - `DELEGATION_WHITELIST_REFRESH_INTERVAL` - Whitelist refresh interval in minutes. If not set default value `10` is used.
+   -  Or disable whitelisting alltogether by setting `DELEGATION_WHITELIST_DISABLED=1`. The previous env variables are then ignored.
 
 3. **AWS S3 Configuration**:
    - `AWS_ACCOUNT_ID` - Your AWS Account ID.

--- a/src/cmd/delegation_backend/main_bpu.go
+++ b/src/cmd/delegation_backend/main_bpu.go
@@ -121,7 +121,7 @@ func main() {
 	// Sheets service and whitelist loop
 	app.WhitelistDisabled = appCfg.DelegationWhitelistDisabled
 	if app.WhitelistDisabled {
-		log.Infof("delegation whitelist is disabled")
+		log.Infof("Delegation whitelist is disabled")
 	} else {
 		sheetsService, err2 := sheets.NewService(ctx, option.WithScopes(sheets.SpreadsheetsReadonlyScope))
 		if err2 != nil {
@@ -134,17 +134,17 @@ func main() {
 		wlMvar := new(WhitelistMVar)
 		wlMvar.Replace(&initWl)
 		app.Whitelist = wlMvar
-		log.Infof("delegation whitelist is enabled")
+		log.Infof("Delegation whitelist is enabled")
 		go func() {
 			for {
+				time.Sleep(SetWhitelistRefreshInterval(log))
 				wl, err := RetrieveWhitelist(sheetsService, log, appCfg, 10)
 				if err != nil {
-					log.Errorf("Failed to refresh delegation whitelist, using previous whitelist, error: %v", err)
+					log.Errorf("Failed to refresh delegation whitelist, using previous one, error: %v", err)
 				} else {
 					wlMvar.Replace(&wl)
-					log.Infof("delegation whitelist refreshed, number of BPs: %v", len(wl))
+					log.Infof("Delegation whitelist refreshed, number of BPs: %v", len(wl))
 				}
-				time.Sleep(WHITELIST_REFRESH_INTERVAL)
 			}
 		}()
 	}

--- a/src/cmd/delegation_backend/main_bpu.go
+++ b/src/cmd/delegation_backend/main_bpu.go
@@ -123,19 +123,27 @@ func main() {
 	if app.WhitelistDisabled {
 		log.Infof("delegation whitelist is disabled")
 	} else {
-		log.Infof("delegation whitelist is enabled")
 		sheetsService, err2 := sheets.NewService(ctx, option.WithScopes(sheets.SpreadsheetsReadonlyScope))
 		if err2 != nil {
 			log.Fatalf("Error creating Sheets service: %v", err2)
 		}
-		initWl := RetrieveWhitelist(sheetsService, log, appCfg)
+		initWl, err := RetrieveWhitelist(sheetsService, log, appCfg, 1)
+		if err != nil {
+			log.Fatalf("Failed to initialize whitelist: %v", err)
+		}
 		wlMvar := new(WhitelistMVar)
 		wlMvar.Replace(&initWl)
 		app.Whitelist = wlMvar
+		log.Infof("delegation whitelist is enabled")
 		go func() {
 			for {
-				wl := RetrieveWhitelist(sheetsService, log, appCfg)
-				wlMvar.Replace(&wl)
+				wl, err := RetrieveWhitelist(sheetsService, log, appCfg, 10)
+				if err != nil {
+					log.Errorf("Failed to refresh delegation whitelist, using previous whitelist, error: %v", err)
+				} else {
+					wlMvar.Replace(&wl)
+					log.Infof("delegation whitelist refreshed, number of BPs: %v", len(wl))
+				}
 				time.Sleep(WHITELIST_REFRESH_INTERVAL)
 			}
 		}()

--- a/src/delegation_backend/constants.go
+++ b/src/delegation_backend/constants.go
@@ -25,6 +25,25 @@ func NetworkId(networkName string) uint8 {
 	return 0
 }
 
+func SetWhitelistRefreshInterval(log logging.StandardLogger) time.Duration {
+	var defaultValue time.Duration = time.Duration(10) * time.Minute
+	var whitelistRefreshInterval time.Duration
+
+	envVarValue, exists := os.LookupEnv("DELEGATION_WHITELIST_REFRESH_INTERVAL")
+	if exists {
+		minutes, err := strconv.Atoi(envVarValue)
+		if err != nil {
+			log.Warnf("Error parsing DELEGATION_WHITELIST_REFRESH_INTERVAL, falling back to default value: %v, error: %v", defaultValue, err)
+			whitelistRefreshInterval = defaultValue
+		}
+		whitelistRefreshInterval = time.Duration(minutes) * time.Minute
+	} else {
+		whitelistRefreshInterval = defaultValue
+	}
+	log.Infof("Delegation whitelist refresh interval: %v", whitelistRefreshInterval)
+	return whitelistRefreshInterval
+}
+
 func SetRequestsPerPkHourly(log logging.StandardLogger) int {
 	var defaultValue = 120
 	var requestsPerPkHourly int

--- a/src/delegation_backend/sheets.go
+++ b/src/delegation_backend/sheets.go
@@ -27,7 +27,7 @@ func processRows(rows [][](interface{})) Whitelist {
 // Retrieve data from delegation program spreadsheet
 // and extract public keys out of the column containing
 // public keys of program participants.
-func RetrieveWhitelist(service *sheets.Service, log *logging.ZapEventLogger, appCfg AppConfig) Whitelist {
+func RetrieveWhitelist(service *sheets.Service, log *logging.ZapEventLogger, appCfg AppConfig, retries int) (Whitelist, error) {
 	var resp *sheets.ValueRange
 	var err error
 
@@ -41,11 +41,11 @@ func RetrieveWhitelist(service *sheets.Service, log *logging.ZapEventLogger, app
 		}
 		return nil
 	}
-	retries := 10
 	err = ExponentialBackoff(operation, retries, initialBackoff)
 	if err != nil {
 		log.Errorf("Unable to retrieve data from sheet after %v retries: %v", retries, err)
+		return nil, err
 	}
 
-	return processRows(resp.Values)
+	return processRows(resp.Values), nil
 }


### PR DESCRIPTION
Despite exponential backoff strategy when interacting with googleapi the app was crashing when the api was unavailable. This pr fixes this and makes the system use previously retrieved whitelist in case when api is unavailable or returns an error. Additionally I made whitelist refresh interval configurable via env var `DELEGATION_WHITELIST_REFRESH_INTERVAL`. Setting this env var is optional, if not set default `10` minute interval is used.
 